### PR TITLE
Single output file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Bundlewharf Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '23' # Ensure you match your project's Node version
+
+      - name: Update npm packages
+        run: npm update
+
+      - name: Build project with Vite
+        run: npx vite build

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
+# Bundlewharf
 
-This small repo bundle wharfkit into a single javascript file to allow using on a html web page without javascript framework.
+This small repository bundles [wharfkit](https://wharfkit.com/) into a single JavaScript file, making it usable in web apps without Node.js or other JavaScript frameworks. No optimizations are performed; it uses a minimal [Vite](https://vite.dev/) configuration.
 
-No optimisations are done; it uses the simplest vite config.
+## Requirements
+ - Node.js (tested with `v23.1.0`)
+
+> [!NOTE]  
+> It's recommended to use [nvm](https://github.com/nvm-sh/nvm) for the installation of `Node.js`. In case you use `fish` as your shell, you may need additional steps to make `nvm` work, for instance the installation of [fish-nvm](https://github.com/FabioAntunes/fish-nvm).
 
 ## How to use
 
 ```sh
 npm update
-vite build
+npx vite build
 ```
+
+The output will be in the `dist/assets` folder, named `whartfkit.js`.

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,10 @@ export default {
     rollupOptions: {
       input: {
         main: 'index.js' // Assuming your entry file is named index.js
+      },
+      output: {
+       inlineDynamicImports: true, // Force inline all dynamic imports
+       entryFileNames: `dist/assets/wharfkit.js` // Set the output file name
       }
     }
   }


### PR DESCRIPTION
This PR updates the `Vite` configuration so that the build outputs a single JavaScript file named `wharfkit.js`.

I also took the chance to update the readme and include a basic CI workflow.